### PR TITLE
Initial c++ ipp module implementation

### DIFF
--- a/ipp.cpp
+++ b/ipp.cpp
@@ -1,0 +1,800 @@
+/**
+ * C++ implementation of the ipp module.
+ */
+#include "ipp.h"
+
+// Always execute assert()s!
+#undef NDEBUG
+
+#include <cassert>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <tuple>
+
+namespace {
+
+template<typename T>
+T
+readInt(std::ifstream& file) {
+    T val;
+    file.read(reinterpret_cast<char*>(&val), sizeof(val));
+    if (!file.good()) {
+        throw std::runtime_error("Unexpected EOF");
+    }
+    return val;
+}
+
+std::string
+readString(std::ifstream& file) {
+    std::string s;
+    std::getline(file, s, '\0');
+    if (!file.good()) {
+        throw std::runtime_error("Unexpected EOF");
+    }
+    return s;
+}
+
+} // namespace
+
+void
+Ipp::loadPwalns(std::string const& fileName) {
+    // Reads the chromosomes and pwalns from the given file.
+    // The data in the file is expected to be in the following format:
+    //
+    // num_chomosomes            [uint16]
+    // {
+    //   chrom_name              [null-terminated string]
+    // } num_chromosomes times
+    // num_sp1                   [uint8]
+    // {
+    //   sp1_name                [null-terminated string]
+    //   num_sp2                 [uint8]
+    //   {
+    //     sp2_name              [null-terminated string]
+    //     num_ref_chrom_entries [uint32]
+    //     {
+    //       num_pwaln_entries   [uint32]
+    //       {
+    //         ref_start         [uint32]
+    //         ref_end           [uint32]
+    //         qry_start         [uint32]
+    //         qry_end           [uint32]
+    //         ref_chrom         [uint16]
+    //         qry_chrom         [uint16]
+    //       } num_pwaln_entries times
+    //     } num_ref_chrom_entries times
+    //   } num_sp2 times
+    // } num_sp1 times
+    chroms_.clear();
+    pwalns_.clear();
+
+    std::ifstream file(fileName, std::ios::in|std::ios::binary);
+    if (!file.is_open()) {
+        throw std::runtime_error("could not open the file");
+    }
+
+    // Read the chromosomes.
+    auto const numChromosomes(readInt<uint16_t>(file));
+    chroms_.reserve(numChromosomes);
+    for (unsigned i(0); i < numChromosomes; ++i) {
+        chroms_.push_back(readString(file));
+    }
+
+    // Read the pwalns.
+    auto const numSp1(readInt<uint8_t>(file));
+    for (unsigned i(0); i < numSp1; ++i) {
+        // Create new entry in the map if it is not yet there.
+        std::string const sp1(readString(file));
+        auto& pwalnsSp1(pwalns_[sp1]);
+
+        auto const numSp2(readInt<uint8_t>(file));
+        for (unsigned j(0); j < numSp2; ++j) {
+            std::string const sp2(readString(file));
+            auto& pwaln(pwalnsSp1[sp2]);
+
+            auto const numRefChromEntries(readInt<uint32_t>(file));
+            for (unsigned k(0); k < numRefChromEntries; ++k) {
+                auto const numPwalnEntries(readInt<uint32_t>(file));
+
+                // Bulk-read the pwaln entries directly into the pwlanEntries
+                // vector.
+                std::vector<PwalnEntry> pwalnEntries(numPwalnEntries);
+                file.read(reinterpret_cast<char*>(pwalnEntries.data()),
+                          numPwalnEntries*sizeof(PwalnEntry));
+                if (!file.good()) {
+                    throw std::runtime_error("Unexpected EOF");
+                }
+
+                pwaln.insert({pwalnEntries[0].refChrom,
+                              std::move(pwalnEntries)});
+            }
+        }
+    }
+
+    if (file.peek() != std::ifstream::traits_type::eof()) {
+        throw std::runtime_error("Remaining data at EOF");
+        // There is more data to read when we don't expect it.
+    }
+}
+
+void
+Ipp::loadGenomeSizes(std::string const& dirName) {
+    // Reads the genome sizes from the files in the given directory.
+    genomeSizes_.clear();
+
+    for (auto const& it : pwalns_) {
+        std::string const& species(it.first);
+        std::string const fileName(dirName + "/" + species + ".sizes");
+        std::ifstream file(fileName, std::ios::in);
+        if (!file.is_open()) {
+            throw std::runtime_error("could not open the file " + fileName);
+        }
+
+        unsigned genomeSize(0);
+        for (std::string line; std::getline(file, line); ) {
+            auto const spacePos(line.find('\t'));
+            if (spacePos == std::string::npos) {
+                throw std::runtime_error("line with no tabstop in " + fileName);
+            }
+            genomeSize += std::atoi(line.c_str()+spacePos);
+        }
+        genomeSizes_[species] = genomeSize;
+    }
+}
+
+void
+Ipp::setHalfLifeDistance(unsigned halfLifeDistance) {
+    // Sets the half-life distance;
+    halfLifeDistance_ = halfLifeDistance;
+}
+
+uint16_t
+Ipp::chromIdFromName(std::string const& chromName) const {
+    // Looks up the given chromosome name in chroms_ and returns its id.
+    auto const it(std::find(chroms_.begin(), chroms_.end(), chromName));
+    if (it == chroms_.end()) {
+        throw std::runtime_error("Unknown chromosome: " + chromName);
+    }
+    return std::distance(chroms_.begin(), it);
+}
+
+std::string const&
+Ipp::chromName(uint16_t chromId) const {
+    // Returns the name of the chromosome with the given id.
+    return chroms_.at(chromId);
+}
+
+double
+Ipp::getScalingFactor(unsigned genomeSize) const {
+    // Returns the scaling factor that produces a score of 0.5 for
+    // halfLifeDistance_ in the reference species.
+    // This scaling factor will be used in all other species in the graph, but
+    // scaled to the according respective genome sizes.
+    return -1.0d * halfLifeDistance_ / (genomeSize * std::log(0.5));
+}
+
+void
+Ipp::projectCoords(
+    std::string const& refSpecies,
+    std::string const& qrySpecies,
+    std::vector<Coords> const& refCoords,
+    unsigned const nCores,
+    OnProjectCoordsJobDoneCallback const& onJobDoneCallback) const {
+
+    std::mutex mutex;
+    std::vector<Coords> jobs(refCoords);
+
+    bool hadWorkerException(false);
+    std::exception workerException;
+
+    auto const worker = [&]() {
+        while (true) {
+            // Get the next job.
+            Coords refCoord;
+            {
+                std::lock_guard const lockGuard(mutex);
+                if (jobs.empty()) {
+                    // All jobs done.
+                    return;
+                }
+
+                refCoord = jobs.back();
+                jobs.pop_back();
+            }
+
+            // Execute the next job.
+            Ipp::CoordProjection coordProjection;
+            try {
+                coordProjection =
+                    projectCoord(refSpecies, qrySpecies, refCoord);
+            } catch (std::exception const& e) {
+                {
+                    std::lock_guard const lockGuard(mutex);
+                    hadWorkerException = true;
+                    workerException = e;
+                    return;
+                }
+            }
+
+            // Call the callback.
+            {
+                std::lock_guard const lockGuard(mutex);
+                onJobDoneCallback(refCoord, coordProjection);
+            }
+        }
+    };
+
+    if (nCores <= 1) {
+        worker();
+        // Just execute the worker in this thread.
+    } else {
+        // Create the threads.
+        std::vector<std::thread> threads;
+        for (unsigned i(0); i < nCores; ++i) {
+            threads.emplace_back(worker);
+        }
+
+        // Wait for the threads to complete.
+        for (auto& thread : threads) {
+            thread.join();
+        }
+
+        // Forward any exception that occured in a thread.
+        if (hadWorkerException) {
+            throw workerException;
+        }
+    }
+}
+
+Ipp::CoordProjection
+Ipp::projectCoord(std::string const& refSpecies,
+                  std::string const& qrySpecies,
+                  Coords const& refCoords) const {
+    bool const debug(false);
+    if (debug) {
+        std::cout.precision(16);
+        std::cout << std::endl;
+        std::cout << refSpecies << " " << qrySpecies << " "
+                  << refCoords.chrom << ":" << refCoords.loc << std::endl;
+    }
+
+    double const scalingFactor(getScalingFactor(genomeSizes_.at(refSpecies)));
+
+    CoordProjection coordProjection;
+    ShortestPath& shortestPath(coordProjection.multiShortestPath);
+    shortestPath[refSpecies] = { 1.0, "", refCoords, {} };
+
+    struct OrangeEntry {
+        double score;
+        std::string species;
+        Ipp::Coords coords;
+
+        OrangeEntry(double score,
+                    std::string const& species,
+                    Ipp::Coords const& coords)
+            : score(score), species(species), coords(coords)
+        {}
+
+        bool operator<(OrangeEntry const& other) const {
+            return std::tie(score, species, coords)
+                < std::tie(other.score, other.species, other.coords);
+        }
+    };
+    std::priority_queue<OrangeEntry> orange;
+    orange.emplace(1.0, refSpecies, refCoords);
+
+    while (!orange.empty()) {
+        OrangeEntry const current(orange.top());
+        orange.pop();
+
+        auto it(shortestPath.find(current.species));
+        if (it != shortestPath.end() && it->second.score > current.score) {
+            continue;
+            // The current species was already reached by a faster path, ignore
+            // this path and go to the next species.
+        }
+
+        if (debug) {
+            std::cout << "- " << current.species << " " << current.score << " "
+                      << current.coords.chrom << ":" << current.coords.loc
+                      << std::endl;
+        }
+        
+        if (current.species == qrySpecies) {
+            break;
+            // qry species reached, stop.
+        }
+
+        for (auto const& nxt : pwalns_.at(current.species)) {
+            std::string const& nxtSpecies(nxt.first);
+            it = shortestPath.find(nxtSpecies);
+            if (it != shortestPath.end()
+                && current.score <= it->second.score) {
+                continue;
+                // If the score to the current species is lower than any
+                // previous path to nxtSpecies, then nxtSpecies won't be reached
+                // faster through the current species.
+            }
+
+            if (debug) {
+                std::cout << "--> " << nxtSpecies << std::endl;
+            }
+
+            auto const proj(projectGenomicLocation(current.species,
+                                                   nxtSpecies,
+                                                   current.coords,
+                                                   scalingFactor));
+            if (!proj) {
+                continue;
+                // No path was found.
+            }
+
+            if(current.species == refSpecies && nxtSpecies == qrySpecies) {
+                // Direct projection.
+                coordProjection.direct = *proj;
+            }
+
+            double const nxtScore(current.score * proj->score);
+            if (it != shortestPath.end() && nxtScore <= it->second.score) {
+                continue;
+                // Only save the current path to nxtSpecies if it is faster than
+                // any previous path to it.
+            }
+
+            shortestPath[nxtSpecies] = {
+                nxtScore,
+                current.species,
+                proj->nextCoords,
+                proj->anchors
+            };
+            orange.emplace(nxtScore, nxtSpecies, proj->nextCoords);
+        }
+    }
+
+    return coordProjection;
+}
+
+namespace {
+
+template<typename T>
+void
+updateChromCount(std::unordered_map<uint16_t, unsigned>& chromCount,
+                 T const& v) {
+    for (Ipp::PwalnEntry const& entry : v) {
+        ++chromCount[entry.qryChrom];
+    }
+}
+
+template<typename T, typename... Args>
+void
+updateChromCount(std::unordered_map<uint16_t, unsigned>& chromCount,
+                 T const& v,
+                 Args const&... args) {
+    updateChromCount(chromCount, v);
+    updateChromCount(chromCount, args...);
+}
+
+template<typename... Args>
+uint16_t
+computeMajorChrom(Args const&... args) {
+    std::unordered_map<uint16_t, unsigned> chromCount;
+    updateChromCount(chromCount, args...);
+
+    unsigned maxCount(0);
+    uint16_t maxChrom(0);
+    for (auto const& [chrom, count] : chromCount) {
+        if (count > maxCount) {
+            maxChrom = chrom;
+            maxCount = count;
+        }
+    }
+    return maxChrom;
+}
+
+template<typename T>
+void
+removeEntriesWithNonMajorQryChromosome(T& anchors, uint16_t majorChrom) {
+    for (auto it(anchors.begin()); it != anchors.end(); ) {
+        if (it->qryChrom != majorChrom) {
+            it = anchors.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+} // namespace
+
+std::optional<Ipp::GenomicProjectionResult>
+Ipp::projectGenomicLocation(std::string const& refSpecies,
+                            std::string const& qrySpecies,
+                            Coords const& refCoords,
+                            double scalingFactor) const {
+    auto const it1(pwalns_.find(refSpecies));
+    if (it1 == pwalns_.end()) {
+        // There is no pairwise alignment for the ref species.
+        return {};
+    }
+    auto const it2(it1->second.find(qrySpecies));
+    if (it2 == it1->second.end()) {
+        // There is no pairwise alignment for the qry species.
+        return {};
+    }
+
+    auto const anchors(getAnchors(it2->second, refCoords));
+    if (!anchors) {
+        // If no or only one anchor is found because of border region, return 0
+        // score and empty coordinate string.
+        return {};
+    }
+
+    uint32_t const refLoc(refCoords.loc);
+
+    // Compute the qryLoc by linear interpolation: Consider where refLoc lies
+    // between the ref coords of the up- and downstream anchors and project that
+    // to the qry coords of the anchors.
+    uint32_t refLeftBound, refRightBound, qryLeftBound, qryRightBound;
+    // The qry coords might be reversed (start > end). If the upstream
+    // anchor is reversed then the downstream anchor is, too.
+    bool const isQryReversed(anchors->upstream.isQryReversed());
+    uint32_t const qryUpStart(!isQryReversed
+                              ? anchors->upstream.qryStart
+                              : anchors->downstream.qryEnd);
+    uint32_t const qryUpEnd(!isQryReversed
+                            ? anchors->upstream.qryEnd
+                            : anchors->downstream.qryStart);
+    assert(qryUpStart < qryUpEnd);
+    if (anchors->upstream == anchors->downstream) {
+        // refLoc lies on an aligment.
+        //  [  up.ref  ]
+        //  [ down.ref ]
+        //          x
+        refLeftBound = anchors->upstream.refStart;
+        refRightBound = anchors->upstream.refEnd;
+        qryLeftBound = qryUpStart;
+        qryRightBound = qryUpEnd;
+    } else {
+        // [ up.ref ]  x    [ down.ref ]
+        uint32_t const qryDownStart(!isQryReversed
+                                    ? anchors->downstream.qryStart
+                                    : anchors->upstream.qryEnd);
+        uint32_t const qryDownEnd(!isQryReversed
+                                  ? anchors->downstream.qryEnd
+                                  : anchors->upstream.qryStart);
+        assert(qryUpEnd <= qryDownStart && qryDownStart < qryDownEnd);
+
+        refLeftBound= anchors->upstream.refEnd;
+        refRightBound = anchors->downstream.refStart; 
+        qryLeftBound = qryUpEnd;
+        qryRightBound = qryDownStart;
+    }
+    assert(refLeftBound <= refLoc && refLoc < refRightBound);
+    double const relativeRefLoc(
+        1.0d*(refLoc - refLeftBound) / (refRightBound - refLeftBound));
+    uint32_t const qryLoc(
+        qryLeftBound + relativeRefLoc*(qryRightBound - qryLeftBound));
+    // ONLY USE DISTANCE TO CLOSE ANCHOR AT REF SPECIES, because at the qry
+    // species it should be roughly the same as it is a projection of the
+    // reference.
+
+    double const score(projectionScore(refLoc,
+                                       refLeftBound,
+                                       refRightBound,
+                                       genomeSizes_.at(refSpecies),
+                                       scalingFactor));
+
+    return {{score, {anchors->upstream.qryChrom, qryLoc}, *anchors}};
+}
+
+std::optional<Ipp::Anchors>
+Ipp::getAnchors(Pwaln const& pwaln, Coords const& refCoords) const {
+    // First define anchors upstream, downstream and ovAln, then do major-chrom
+    // and collinearity test, then either return overlapping anchor or closest
+    // anchors.
+    // Take orientation into account for the anchor definition. If start > end,
+    // then the aln is to the '-' strand.
+    // For speed reasons only select the first `topn` entries. The rest just
+    // takes longer to compute min / max and most likely will (and should) not
+    // be an anchor anyways.
+
+    // Test collinearity of anchors: take top 20 in each direction (top 10 
+    // produced many locally collinear pwalns that were still non-collinear
+    // outliers in the global view of the GRB).
+    // Note: using ungapped chain blocks might require n to be even larger.
+    unsigned const minn(5);
+    unsigned const topn(20);
+
+    auto const compGreaterRefEnd = [](PwalnEntry const& lhs,
+                                      PwalnEntry const& rhs) {
+        return lhs.refEnd > rhs.refEnd;
+    };
+
+    uint32_t const refLoc(refCoords.loc);
+
+    // Find the topn entries by largest(smallest) refEnd(refStart) in the
+    // upstream(downstream) anchors.
+    std::set<PwalnEntry, decltype(compGreaterRefEnd)> anchorsUpstream(
+        compGreaterRefEnd);
+    std::vector<PwalnEntry> ovAln;
+    std::vector<PwalnEntry> anchorsDownstream;
+    for (auto const& pwalnEntry : pwaln.at(refCoords.chrom)) {
+        if (pwalnEntry.refEnd <= refLoc) { // refEnd is exclusive
+            // upstream anchor
+            // [ anchor ]    x
+            anchorsUpstream.insert(pwalnEntry);
+            if(anchorsUpstream.size() > 10*topn) {
+                // Remove surplus anchors that are too far away. We do that
+                // heuristically once we reach 10 times the maximum number to
+                // amortize the cost.
+                anchorsUpstream.erase(std::next(anchorsUpstream.begin(), topn),
+                                      anchorsUpstream.end());
+            }
+        } else if (refLoc < pwalnEntry.refStart) {
+            // downstream anchor
+            //    x     [ anchor ]
+            anchorsDownstream.push_back(pwalnEntry);
+            if(anchorsDownstream.size() == topn) {
+                // We found the topn closest anchors with refStart > refLoc.
+                // Since the pwalnEntries are sorted by refStart, all the
+                // anchers to come are further away than what we have already
+                // seen.
+                break;
+            }
+        } else {
+            // refLoc lies on an alignment block.
+            // [ anchor ]
+            //      x
+            ovAln.push_back(pwalnEntry);
+        }
+    }
+
+    // Trim anchorsUpstream to only contain the topn closest entries.
+    if(anchorsUpstream.size() > topn) {
+        anchorsUpstream.erase(std::next(anchorsUpstream.begin(), topn),
+                              anchorsUpstream.end());
+    }
+
+    // MAJOR CHROMOSOME: Retain anchors that point to the majority chromosome in
+    // top n of both up- and downstream anchors.
+    uint16_t const majorChrom(
+        computeMajorChrom(ovAln, anchorsUpstream, anchorsDownstream));
+    removeEntriesWithNonMajorQryChromosome(anchorsUpstream, majorChrom);
+    removeEntriesWithNonMajorQryChromosome(ovAln, majorChrom);
+    removeEntriesWithNonMajorQryChromosome(anchorsDownstream, majorChrom);
+  
+    if (!anchorsUpstream.size() || !anchorsDownstream.size()) {
+        // Require minimum of 1 anchor on each side. Later, the minimum total
+        // number of collinear anchors will be set to `minn` (but one side is
+        // allowed to have as little as 1 anchor).
+        return {};
+    }
+
+    // COLLINEARITY: Remove pwalns pointing to outliers by getting the longest
+    // sorted subsequence of the top n of both up- and downstream anchors.
+    std::vector<PwalnEntry> closestAnchors;
+    closestAnchors.insert(closestAnchors.begin(), anchorsUpstream.begin(), anchorsUpstream.end());
+    closestAnchors.insert(closestAnchors.end(), ovAln.begin(), ovAln.end());
+    closestAnchors.insert(closestAnchors.end(), anchorsDownstream.begin(), anchorsDownstream.end());
+
+    // Sort the closestAnchors entries by increasing refStart. That is necessary
+    // as the anchorsUpstream were previously sorted by decreasing refEnd.
+    auto const compLessRefStart = [](PwalnEntry const& lhs,
+                                     PwalnEntry const& rhs) {
+        return std::tie(lhs.refStart, lhs.refEnd)
+            < std::tie(rhs.refStart, rhs.refEnd);
+    };
+    std::sort(closestAnchors.begin(), closestAnchors.end(), compLessRefStart);
+
+    closestAnchors = longestSubsequence(closestAnchors);
+
+    // Set minimum number of collinear anchors to `minn` (for species pairs with
+    // very large evol. distances setting a lower boundary for the number of
+    // collinear anchors will help reduce false positives).
+    if (closestAnchors.size() < minn) {
+        return {};
+    }
+  
+    // Check if the original ovAln is still present (or ever was) in the
+    // filtered closestAnchors (that include a potential ovAln);
+    // if not, it was an outlier alignment and was filtered out
+    // if yes, narrow it to the actual position of refLoc and its relative
+    // position in the qry such that the returned anchors have distance = 0 to
+    // refLoc.
+    PwalnEntry const* closestUpstreamAnchor(nullptr);
+    PwalnEntry const* closestOvAlnAnchor(nullptr);
+    PwalnEntry const* closestDownstreamAnchor(nullptr);
+    for (auto const& anchor : closestAnchors) {
+        if (anchor.refEnd <= refLoc) {
+            if (!closestUpstreamAnchor
+                || closestUpstreamAnchor->refEnd < anchor.refEnd) {
+                closestUpstreamAnchor = &anchor;
+            }
+        } else if (refLoc < anchor.refStart) {
+            if (!closestDownstreamAnchor
+                || anchor.refStart < closestDownstreamAnchor->refStart) {
+                closestDownstreamAnchor = &anchor;
+
+                // The anchors that follow this one will only be worse.
+                break;
+            }
+        } else {
+            if(!closestOvAlnAnchor) {
+                closestOvAlnAnchor = &anchor;
+            } else {
+                auto const absDiff = [](uint32_t a, uint32_t b) {
+                    return a > b ? a-b : b-a;
+                };
+                uint32_t const minDistNew(
+                    std::min(absDiff(closestOvAlnAnchor->refStart, refLoc),
+                             absDiff(closestOvAlnAnchor->refEnd, refLoc)));
+                uint32_t const minDistOld(
+                    std::min(absDiff(anchor.refStart, refLoc),
+                             absDiff(anchor.refEnd, refLoc)));
+                if (minDistNew < minDistOld) {
+                    closestOvAlnAnchor = &anchor;
+                }
+            }
+        }
+    }
+    if (closestOvAlnAnchor) {
+        //uint32_t const locRelative(refLoc - closestOvAlnAnchor->refStart);
+        //bool const isPositiveStrand(
+        //    closestOvAlnAnchor->qryStart < closestOvAlnAnchor->qryEnd);
+
+        //PwalnEntry anchorUp(*closestOvAlnAnchor);
+        //anchorUp.refStart = refLoc - 1;
+        //anchorUp.refEnd = refLoc;
+        //anchorUp.qryStart = isPositiveStrand
+        //    ? closestOvAlnAnchor->qryStart + locRelative - 1
+        //    : closestOvAlnAnchor->qryStart - locRelative + 2;
+        //anchorUp.qryEnd = isPositiveStrand
+        //    ? closestOvAlnAnchor->qryStart + 1
+        //    : closestOvAlnAnchor->qryStart - 1;
+    
+        //PwalnEntry anchorDown(anchorUp);
+        //anchorDown.refStart += 1;
+        //anchorDown.refEnd += 1;
+        //anchorDown.qryStart += isPositiveStrand ? 1 : -1;
+        //anchorDown.qryEnd += isPositiveStrand ? 1 : -1;
+
+        //return {{anchorUp, anchorDown}};
+        return {{*closestOvAlnAnchor, *closestOvAlnAnchor}};
+    } else {
+        if (!closestUpstreamAnchor || !closestDownstreamAnchor) {
+            // Not both up- and downstream anchors were found (e.g. at synteny
+            // break points where one side does not have any anchors to the
+            // majority chromosome)
+            return {};
+        }
+
+        return {{*closestUpstreamAnchor, *closestDownstreamAnchor}};
+    }
+}
+
+namespace {
+
+template<typename Compare, typename Filter>
+std::vector<Ipp::PwalnEntry>
+longestSubsequence(std::vector<Ipp::PwalnEntry> const& seq,
+                   Compare const& greaterThan,
+                   Filter const& filter) {
+    // Finds the longest strictly increasing subsequence (in regards to the
+    // given greater-than function). Only elements for which filter(seq[i])
+    // returns true are considered.
+    // O(n log k) algorithm.
+
+    // m[i] contains the index to the smallest value in seq[] that is the end of
+    // a subsequence of length i.
+    std::vector<unsigned> m;
+    m.reserve(seq.size());
+
+    if (!seq.size()) {
+        return {};
+    }
+
+    // prev[i] contains the index of the element in seq that is the one before
+    // seq[i] in the longest subsequence for seq[i].
+    std::vector<unsigned> prev(seq.size());
+
+    for (unsigned i(0); i < seq.size(); ++i) {
+        // If the next element seq[i] is greater than the last element of the
+        // current longest subsequence seq[m.back()], just push it to the end of
+        // `m` and continue.
+        if (!filter(seq[i])) {
+            continue;
+        }
+
+        if (!m.size()) {
+            // This is the first element that matches the filter. Just add it to
+            // m.
+            m.push_back(i);
+            continue;
+        }
+
+        if (greaterThan(seq[i], seq[m.back()])) {
+            prev[i] = m.back();
+            m.push_back(i);
+            continue;
+        }
+
+        // Binary search to find the smallest element referenced by m which is
+        // just bigger than seq[i].
+        // Note : Binary search is performed on m (and not seq).
+        // Size of m is always <=i and hence contributes O(log i) to the
+        // complexity.
+        unsigned u(0);
+        unsigned v(m.size()-1);
+        while(u < v) {
+            unsigned const mid((u + v) / 2);
+            if (greaterThan(seq[i], seq[m[mid]])) {
+                u = mid+1;
+            } else {
+                v = mid;
+            }
+        }
+
+        // Update m if the new value is smaller than the previously referenced
+        // one.
+        if (greaterThan(seq[m[u]], seq[i])) {
+            if (u > 0) {
+                prev[i] = m[u-1];
+            }
+            m[u] = i;
+        }
+    }
+
+    // Backtrace the longest subsequence into res.
+    std::vector<Ipp::PwalnEntry> res(m.size());
+    unsigned v(m.back());
+    for (unsigned u(m.size()); u; --u) {
+        res[u-1] = seq[v];
+        v = prev[v];
+    }
+    return res;
+}
+
+} // namespace
+
+std::vector<Ipp::PwalnEntry>
+Ipp::longestSubsequence(std::vector<PwalnEntry> const& seq) {
+    std::vector<PwalnEntry> const inc(::longestSubsequence(
+            seq,
+            [](PwalnEntry const& lhs, PwalnEntry const& rhs) {
+                return lhs.qryStart > rhs.qryStart;
+            },
+            [](PwalnEntry const& e) {
+                return !e.isQryReversed();
+            }));
+
+    std::vector<PwalnEntry> const dec(::longestSubsequence(
+            seq,
+            [](PwalnEntry const& lhs, PwalnEntry const& rhs) {
+                return lhs.qryEnd < rhs.qryEnd;
+            },
+            [](PwalnEntry const& e) {
+                return e.isQryReversed();
+            }));
+
+    return inc.size() >= dec.size() ? inc : dec;
+}
+
+double
+Ipp::projectionScore(uint32_t loc,
+                     uint32_t leftBound,
+                     uint32_t rightBound,
+                     unsigned genomeSize,
+                     double scalingFactor) const {
+    // Anchors must be the locations of the up- and downstream anchors, not the
+    // data frame with ref and qry coordinates.
+    // The scaling factor determines how fast the function falls when moving
+    // away from an anchor.
+    // Ideally, we define a half-life X_half, i.e. at a distance of X_half, the
+    // model is at 0.5. With a scaling factor of 50 kb, X_half is at 20 kb (with
+    // 100 kb at 10 kb).
+    uint32_t const d(std::min(loc - leftBound, rightBound - loc));
+    return std::exp(-1.0d * d / (genomeSize * scalingFactor));
+}

--- a/ipp.h
+++ b/ipp.h
@@ -1,0 +1,174 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class Ipp {
+public:
+    struct PwalnEntry {
+        // Attention: Keep the below order of the members for alignment reasons!
+        uint32_t refStart;
+        uint32_t refEnd;
+        uint32_t qryStart;
+        uint32_t qryEnd;
+        uint16_t refChrom;
+        uint16_t qryChrom;
+
+        PwalnEntry() {}
+        PwalnEntry(PwalnEntry const& other)
+            : refStart(other.refStart)
+            , refEnd(other.refEnd)
+            , qryStart(other.qryStart)
+            , qryEnd(other.qryEnd)
+            , refChrom(other.refChrom)
+            , qryChrom(other.qryChrom)
+        {}
+
+        bool isQryReversed() const {
+            return qryStart > qryEnd;
+        }
+
+        bool operator==(PwalnEntry const& other) const {
+            return refChrom == other.refChrom
+                && refStart == other.refStart
+                && refEnd == other.refEnd
+                && qryChrom == other.qryChrom
+                && qryStart == other.qryStart
+                && qryEnd == other.qryEnd;
+        }
+    };
+    using Pwaln = std::unordered_map<uint16_t, std::vector<PwalnEntry>>;
+    using Pwalns = std::unordered_map<std::string, std::unordered_map<std::string, Pwaln>>;
+    // The map of pairwise alignments: [sp1][sp2][ref_chrom] -> [PwalnEntry]
+    // The entries in the vector are sorted by [refStart, qryChrom, qryStart].
+    // refChrom is the key and also in the entry as PwalnEntry has enough space
+    // to keep it (due to alignment) and that way we can bulk-read the data in
+    // loadPwalns().
+
+    void loadPwalns(std::string const& fileName);
+    // Reads the chromosomes and pwalns from the given file.
+
+    void loadGenomeSizes(std::string const& dirName);
+    // Reads the genome sizes from the files in the given directory.
+
+    void setHalfLifeDistance(unsigned halfLifeDistance);
+    // Sets the half-life distance.
+
+    uint16_t chromIdFromName(std::string const& chromName) const;
+    // Looks up the given chromosome name in chroms_ and returns its id.
+
+    std::string const& chromName(uint16_t chromId) const;
+    // Returns the name of the chromosome with the given id.
+
+    struct Coords {
+        uint16_t chrom;
+        uint32_t loc;
+
+        Coords() {}
+        Coords(uint16_t chrom, uint32_t loc) : chrom(chrom), loc(loc) {}
+
+        bool operator<(Coords const& other) const {
+            return std::tie(chrom, loc) < std::tie(other.chrom, other.loc);
+        }
+    };
+
+    struct Anchors {
+        PwalnEntry upstream;
+        PwalnEntry downstream;
+
+        Anchors() {}
+        Anchors(PwalnEntry upstream, PwalnEntry downstream)
+            : upstream(upstream)
+            , downstream(downstream)
+        {}
+    };
+
+    struct ShortestPathEntry {
+        double score;
+        std::string prevSpecies;
+        Coords coords;
+        Anchors anchors;
+
+        ShortestPathEntry() {}
+        ShortestPathEntry(double score, 
+                          std::string const& prevSpecies,
+                          Coords const& coords,
+                          Anchors const& anchors)
+            : score(score)
+            , prevSpecies(prevSpecies)
+            , coords(coords)
+            , anchors(anchors)
+        {}
+    };
+    using ShortestPath = std::unordered_map<std::string, ShortestPathEntry>;
+
+    struct GenomicProjectionResult {
+        double score;
+        Coords nextCoords;
+        Anchors anchors;
+
+        GenomicProjectionResult() {}
+        GenomicProjectionResult(double score,
+                                Coords const& nextCoords,
+                                Anchors const& anchors)
+            : score(score)
+            , nextCoords(nextCoords)
+            , anchors(anchors)
+        {}
+    };
+
+    struct CoordProjection {
+        std::optional<GenomicProjectionResult> direct;
+        ShortestPath multiShortestPath;
+    };
+
+    using OnProjectCoordsJobDoneCallback =
+        std::function<void(Ipp::Coords const&, Ipp::CoordProjection const&)>;
+
+    void projectCoords(
+        std::string const& refSpecies,
+        std::string const& qrySpecies,
+        std::vector<Coords> const& refCoords,
+        unsigned const nCores,
+        OnProjectCoordsJobDoneCallback const& onJobDoneCallback) const;
+
+private:
+    CoordProjection projectCoord(std::string const& refSpecies,
+                                 std::string const& qrySpecies,
+                                 Coords const& refCoords) const;
+
+    std::optional<GenomicProjectionResult> projectGenomicLocation(
+        std::string const& refSpecies,
+        std::string const& qrySpecies,
+        Coords const& refCoords,
+        double scalingFactor) const;
+
+    std::optional<Anchors> getAnchors(Pwaln const& pwaln,
+                                      Coords const& refCoords) const;
+
+    static std::vector<PwalnEntry> longestSubsequence(
+        std::vector<PwalnEntry> const& seq);
+    // Searches the longest strictly increasing or decreasing subsequence of seq
+    // and puts it in res.
+    // O(n log k) algorithm.
+
+    double getScalingFactor(unsigned genomeSize) const;
+
+    double projectionScore(uint32_t loc,
+                           uint32_t leftBound,
+                           uint32_t rightBound,
+                           unsigned genomeSize,
+                           double scalingFactor) const;
+
+private:
+    std::vector<std::string> chroms_;
+    Pwalns pwalns_;
+    std::unordered_map<std::string, unsigned> genomeSizes_;
+    unsigned halfLifeDistance_;
+};
+
+

--- a/ippmodule.cpp
+++ b/ippmodule.cpp
@@ -1,0 +1,274 @@
+/**
+ * Defines the "ipp" Python module and translates the calls to the Ipp class.
+ */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ipp.h"
+
+namespace {
+
+template <typename ...Args>
+std::string
+format(char const* fmt, Args&& ...args) {
+    auto const len(std::snprintf(nullptr, 0, fmt, std::forward<Args>(args)...));
+
+    std::string ret(len+1, '\0');
+    std::sprintf(ret.data(), fmt, std::forward<Args>(args)...);
+    return ret;
+}
+
+} // namespace
+
+
+extern "C" {
+
+struct PyIpp {
+    PyObject_HEAD
+
+    Ipp ipp;
+};
+
+static PyObject*
+ippNew(PyTypeObject* type, PyObject* args, PyObject* kwds) {
+    auto const self(reinterpret_cast<PyIpp*>(type->tp_alloc(type, 0)));
+    if (self != nullptr) {
+        // In-place construct the Ipp instance.
+        new (&self->ipp) Ipp();
+    }
+    return (PyObject *) self;
+}
+
+static PyObject*
+ippLoadPwalns(PyIpp* self, PyObject* args) {
+    // Reads the pwalns from the given file.
+    char const* fileName;
+    if (!PyArg_ParseTuple(args,"s", &fileName)) {
+        return nullptr;
+    }
+
+    try {
+        self->ipp.loadPwalns(fileName);
+    } catch (std::exception const& e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+        return nullptr;
+    }
+
+    Py_RETURN_NONE;
+}
+
+static PyObject*
+ippLoadGenomeSizes(PyIpp* self, PyObject* args) {
+    // Reads the genome sizes from the files in the given directory.
+    char const* dirName;
+    if (!PyArg_ParseTuple(args,"s", &dirName)) {
+        return nullptr;
+    }
+
+    try {
+        self->ipp.loadGenomeSizes(dirName);
+    } catch (std::exception const& e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+        return nullptr;
+    }
+
+    Py_RETURN_NONE;
+}
+
+static PyObject*
+ippSetHalfLifeDistance(PyIpp* self, PyObject* args) {
+    // Sets the half-life distance.
+    unsigned halfLifeDistance;
+    if (!PyArg_ParseTuple(args,"I", &halfLifeDistance)) {
+        return nullptr;
+    }
+
+    self->ipp.setHalfLifeDistance(halfLifeDistance);
+
+    Py_RETURN_NONE;
+}
+
+static PyObject*
+ippProjectCoords(PyIpp* self, PyObject* args) {
+    char const* refSpecies;
+    char const* qrySpecies;
+    PyObject* pyRefCoords; // [ (chrom1, loc1), (chrom2, loc2), ... ]
+    unsigned nCores;
+    PyObject* callback;
+    int res(PyArg_ParseTuple(args,
+                             "ssO!IO",
+                             &refSpecies,
+                             &qrySpecies,
+                             &PyList_Type, &pyRefCoords,
+                             &nCores,
+                             &callback));
+    if (!res) {
+        return nullptr;
+    }
+    if (!PyCallable_Check(callback)) {
+        PyErr_SetString(PyExc_TypeError, "callback parameter must be callable");
+        return nullptr;
+    }
+
+    // Parse the ref coords from the given list of tuples.
+    std::vector<Ipp::Coords> refCoords;
+    refCoords.reserve(PyList_Size(pyRefCoords));
+    for (unsigned i(0); i < PyList_Size(pyRefCoords); ++i) {
+        PyObject* const coordsEntry(PyList_GetItem(pyRefCoords, i));
+
+        char const* refCoordsChromName;
+        uint32_t refCoordsLoc;
+        if (!PyArg_ParseTuple(coordsEntry,
+                              "sI",
+                              &refCoordsChromName,
+                              &refCoordsLoc)) {
+            return nullptr;
+        }
+
+        refCoords.emplace_back(self->ipp.chromIdFromName(refCoordsChromName),
+                               refCoordsLoc);
+    }
+
+    auto const onJobDone = [&](Ipp::Coords const& refCoord,
+                               Ipp::CoordProjection const& coordProjection) {
+        // Call the given callback from the python script.
+        auto const coordsStr = [self](Ipp::Coords const& coords) {
+            return format("%s:%u",
+                          self->ipp.chromName(coords.chrom).c_str(),
+                          coords.loc);
+        };
+        auto const refAnchorStr = [](Ipp::PwalnEntry const& anchor) {
+            return format("%u:%u", anchor.refStart, anchor.refEnd);
+        };
+        auto const qryAnchorStr = [](Ipp::PwalnEntry const& anchor) {
+            return format("%u:%u", anchor.qryStart, anchor.qryEnd);
+        };
+
+        // Backtrace the shortest path from the reference to the given target
+        // species (in reversed order).
+        PyObject* const multiShortestPath(PyList_New(0));
+        std::string currentSpecies(qrySpecies);
+        while (!currentSpecies.empty()) {
+            Ipp::ShortestPathEntry const& current(
+                coordProjection.multiShortestPath.at(currentSpecies));
+            PyObject* const tuple(
+                Py_BuildValue("sds(ss)(ss)",
+                              currentSpecies.c_str(),
+                              current.score,
+                              coordsStr(current.coords).c_str(),
+                              refAnchorStr(current.anchors.upstream).c_str(),
+                              refAnchorStr(current.anchors.downstream).c_str(),
+                              qryAnchorStr(current.anchors.upstream).c_str(),
+                              qryAnchorStr(current.anchors.downstream).c_str()));
+            PyList_Append(multiShortestPath, tuple);
+            Py_DECREF(tuple);
+            currentSpecies = current.prevSpecies;
+        }
+
+        // Reverse the shortest path list to have it in the right order.
+        PyList_Reverse(multiShortestPath);
+
+        // Call the callback function.
+        PyObject* argList;
+        if (coordProjection.direct.has_value()) {
+            argList = Py_BuildValue(
+                "sds(ss)(ss)O",
+                coordsStr(refCoord).c_str(),
+                coordProjection.direct->score,
+                coordsStr(coordProjection.direct->nextCoords).c_str(),
+                refAnchorStr(coordProjection.direct->anchors.upstream).c_str(),
+                refAnchorStr(coordProjection.direct->anchors.downstream).c_str(),
+                qryAnchorStr(coordProjection.direct->anchors.upstream).c_str(),
+                qryAnchorStr(coordProjection.direct->anchors.downstream).c_str(),
+                multiShortestPath);
+        } else {
+            argList = Py_BuildValue("sds(ss)(ss)O",
+                                    coordsStr(refCoord).c_str(),
+                                    0.0d,
+                                    nullptr,
+                                    nullptr,
+                                    nullptr,
+                                    nullptr,
+                                    nullptr,
+                                    multiShortestPath);
+        }
+        PyObject* const result(PyObject_CallObject(callback, argList));
+        Py_DECREF(argList);
+        Py_DECREF(multiShortestPath);
+
+        if (!result) {
+            // An error occured.
+            throw std::runtime_error("Error in the callback function");
+        }
+        Py_DECREF(result);
+    };
+
+    // Do the coord projection.
+    try {
+        self->ipp.projectCoords(refSpecies,
+                                qrySpecies,
+                                refCoords,
+                                nCores,
+                                onJobDone);
+    } catch (std::exception const&) {
+        return nullptr;
+    }
+
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef ippMethods[] = {
+    {"load_pwalns", (PyCFunction)ippLoadPwalns, METH_VARARGS, "Reads the chromosomes and pwalns from the given file"},
+    {"load_genome_sizes", (PyCFunction)ippLoadGenomeSizes, METH_VARARGS, "Reads the genome sizes from the files in the given directory"},
+    {"set_half_life_distance", (PyCFunction)ippSetHalfLifeDistance, METH_VARARGS, "Sets the half-life distance"},
+    {"project_coords", (PyCFunction)ippProjectCoords, METH_VARARGS, ""},
+
+    {nullptr, nullptr, 0, nullptr}        /* Sentinel */
+};
+static PyTypeObject PyIpp_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+
+    .tp_name = "ipp.Ipp",
+    .tp_basicsize = sizeof(PyIpp),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = ippMethods,
+    .tp_new = ippNew,
+};
+
+static struct PyModuleDef ippModule = {
+    PyModuleDef_HEAD_INIT,
+    "ipp",   /* name of module */
+    nullptr, /* module documentation, may be NULL */
+    -1,      /* size of per-interpreter state of the module,
+                or -1 if the module keeps state in global variables. */
+    nullptr
+};
+
+PyMODINIT_FUNC
+PyInit_ipp(void) {
+    if (PyType_Ready(&PyIpp_Type) < 0) {
+        return nullptr;
+    }
+
+    PyObject* const m(PyModule_Create(&ippModule));
+    if (!m) {
+        return nullptr;
+    }
+
+    Py_INCREF(&PyIpp_Type);
+    if (PyModule_AddObject(m, "Ipp", (PyObject*)&PyIpp_Type) < 0) {
+        Py_DECREF(&PyIpp_Type);
+        Py_DECREF(m);
+        return nullptr;
+    }
+
+    return m;
+}
+
+} // extern "C"

--- a/pickle_to_bin.py
+++ b/pickle_to_bin.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Converts a pickle file to a binary pwalns file that is readable by the c++ ipp
+# module.
+#
+# Format:
+#   num_chomosomes            [uint16]
+#   {
+#     chrom_name              [null-terminated string]
+#   } num_chromosomes times
+#   num_sp1                   [uint8]
+#   {
+#     sp1_name                [null-terminated string]
+#     num_sp2                 [uint8]
+#     {
+#       sp2_name              [null-terminated string]
+#       num_ref_chrom_entries [uint32]
+#       {
+#         num_pwaln_entries   [uint32]
+#         {
+#           ref_start         [uint32]
+#           ref_end           [uint32]
+#           qry_start         [uint32]
+#           qry_end           [uint32]
+#           ref_chrom         [uint16]
+#           qry_chrom         [uint16]
+#         } num_pwaln_entries times
+#       } num_ref_chrom_entries times
+#     } num_sp2 times
+#   } num_sp1 times
+import argparse
+import pickle
+import sys
+import tqdm
+
+parser = argparse.ArgumentParser()
+parser.add_argument('pickle_file')
+args = parser.parse_args()
+
+# Load the data from the picke file.
+with open(args.pickle_file, 'rb') as f:
+    data = pickle.load(f)
+    chroms = data["chromosomes"]
+    pwalns = data["pwaln"]
+
+# Compute the total number of rows to complete.
+print("Sorting and removing duplicates from the pwalns")
+total_pwalns = 0
+for _, v in pwalns.items():
+    total_pwalns += len(v)
+    
+pbar = tqdm.tqdm(total=total_pwalns, leave=False)
+total_rows = 0
+for _, v in pwalns.items():
+    for _, df in v.items():
+        # Sort the df and compute how many rows there are with the same
+        # ref_chrom value.
+        df.sort_values(by=["ref_chrom", "ref_start", "qry_chrom", "qry_start"],
+                       ignore_index=True,
+                       inplace=True)
+        df.drop_duplicates(ignore_index=True, inplace=True)
+        total_rows += df.shape[0]
+        pbar.update()
+pbar.close()
+
+# Write the binary output file.
+print("Writing the output file")
+pbar = tqdm.tqdm(total=total_rows, leave=False)
+outfile = args.pickle_file.replace('.pkl', '.bin')
+with open(outfile, "wb") as out:
+    def write_int(i, length):
+        out.write(int(i).to_bytes(length, byteorder=sys.byteorder))
+
+    def write_str(s):
+        out.write(s.encode())
+        out.write(b'\x00')
+
+    write_int(len(chroms), 2)
+    for chrom in chroms:
+        write_str(chrom)
+
+    write_int(len(pwalns), 1)
+    for sp1, v in pwalns.items():
+        write_str(sp1)
+        write_int(len(v), 1)
+        for sp2, df in v.items():
+            ref_chrom_counts = df.ref_chrom.value_counts(sort=False)
+
+            write_str(sp2)
+            write_int(len(ref_chrom_counts), 4)
+
+            last_ref_chrom = None
+            for row in df.itertuples(index=False):
+                if row.ref_chrom != last_ref_chrom:
+                    # This is a new ref_chrom -> write a new "header"
+                    write_int(ref_chrom_counts[row.ref_chrom], 4)
+                    last_ref_chrom = row.ref_chrom
+                write_int(row.ref_start, 4)
+                write_int(row.ref_end, 4)
+                write_int(row.qry_start, 4)
+                write_int(row.qry_end, 4)
+                write_int(row.ref_chrom, 2)
+                write_int(row.qry_chrom, 2)
+                pbar.update()
+pbar.close()

--- a/project.py
+++ b/project.py
@@ -1,172 +1,105 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
+import argparse
+import ipp
+import numpy as np
+import os
+import pandas as pd
+import tqdm
 
-import numpy as np, pandas as pd, sys, pickle, argparse, multiprocessing as mp, ctypes, traceback, tqdm
-# from joblib import Parallel, delayed
-from functions import *
-
-# set global variables
-pwaln = {} # assigned in load_pwaln() for main process and init_worker() for worker process
-chroms = [] # assigned in load_pwaln()
-
-def project_coord_new(coord, ref, qry, genome_size, scaling_factor):
-  return
-
-def project_coord(coord, ref, qry, genome_size, scaling_factor):
-  # direct projection
-  score_direct_projection, coords_direct_projection, ref_anchors_direct, qry_anchors_direct = project_genomic_location(ref, qry, coord, 1.0, pwaln, genome_size, scaling_factor)
-  ref_anchors_direct_left, ref_anchors_direct_right = ref_anchors_direct.split(',')
-  qry_anchors_direct_left, qry_anchors_direct_right = qry_anchors_direct.split(',')
-
-  # multi-species projection
-  species = pwaln.keys()
-  shortest_path_to_qry, shortest_path, orange = get_shortest_path(ref, qry, coord, species, pwaln, genome_size, scaling_factor, verbose=False)
-  score_multi_projection, coords_multi_projection = shortest_path_to_qry.loc[qry,['score','coords']]
-  ref_anchors_multi_left, ref_anchors_multi_right = shortest_path_to_qry['ref_anchors'][1].split(',') # ref anchors of the first species in the path (first non-reference species)
-  qry_anchors_multi_left, qry_anchors_multi_right = shortest_path_to_qry['qry_anchors'][-1].split(',') # qry anchors of the last species in the path
-  bridging_species = ','.join(shortest_path_to_qry.index.values[1:-1])
-  values = [coord, coords_direct_projection, coords_multi_projection,
-           score_direct_projection, score_multi_projection,
-           ref_anchors_direct_left, ref_anchors_direct_right, ref_anchors_multi_left, ref_anchors_multi_right,
-           qry_anchors_direct_left, qry_anchors_direct_right, qry_anchors_multi_left, qry_anchors_multi_right,
-           bridging_species]
-  columns = ['coords_ref', 'coords_direct', 'coords_multi', 'score_direct', 'score_multi', 'ref_anchor_direct_left', 'ref_anchor_direct_right', 'ref_anchor_multi_left', 'ref_anchor_multi_right', 'qry_anchor_direct_left', 'qry_anchor_direct_right', 'qry_anchor_multi_left', 'qry_anchor_multi_right', 'bridging_species']
-  df = pd.DataFrame(values, index=columns).T
-  return df
-
-def load_pwaln(path_pwaln_pkl):
-  # load pwaln pickle and copy to shared memory
-  global pwaln
-  global pwaln_shared
-  global chroms
-  global columns
-  
-  with open(path_pwaln_pkl, "rb") as f:
-    data = pickle.load(f)
-    pwaln = data["pwaln"]
-    chroms = data["chromosomes"]
-    
-  pwaln_shared = {}
-  for sp1, v in pwaln.items():
-      pwaln_shared[sp1] = {}
-      for sp2, df in v.items():
-          columns = df.columns
-          # Remember the columns. They are required to be the same in all data
-          # frames.
-
-          # reserve the shared memory
-          mp_arr = mp.RawArray(ctypes.c_uint32, int(df.size))
-
-          # copy the data from df into the shared memory.
-          mp_arr_np = np.frombuffer(mp_arr, dtype=np.uint32).reshape(df.shape)
-          np.copyto(mp_arr_np, df.to_numpy(dtype=np.uint32))
-          pwaln_shared[sp1][sp2] = mp_arr
-
-def init_worker(pwaln_shared):
-    # Create a wrapper pwaln object that accesses its data from the shared
-    # memory.
-    global pwaln
-    for sp1, v in pwaln_shared.items():
-        pwaln[sp1] = {}
-        for sp2, mp_arr in v.items():
-            mp_arr_np = np.frombuffer(mp_arr, dtype=np.uint32) \
-                .reshape([int(len(mp_arr)/len(columns)), len(columns)])
-            pwaln[sp1][sp2] = pd.DataFrame(mp_arr_np, columns=columns)
-    
 def main():
-  parser = argparse.ArgumentParser(description='Independent Point Projections (IPP).\nA method for projecting genomic point coordinates between genomes with large evolutionary distances.')
-  parser.add_argument('regions_file', help='Bed file containing genomic coordinates. regions with width > 1 will be centered.')
-  parser.add_argument('ref', help='reference species')
-  parser.add_argument('qry', help='query species')
-  parser.add_argument('path_pwaln_pkl')
-  parser.add_argument('--out_dir', default=os.getcwd(), help='directory for output files')
-  parser.add_argument('--half_life_distance', type=int, default=10000, help='distance to closest anchor point at which projection score is 0.5')
-  parser.add_argument('--n_cores', type=int, default=1, help='number of CPUs')
-  parser.add_argument('--quiet', help='do not produce any verbose output')
-  parser.add_argument('--data_dir', default='/project/ipp-data')
-  args = parser.parse_args()
-     
-  # define paths
-  assembly_dir = args.data_dir + '/assembly/'
+    parser = argparse.ArgumentParser(description='Independent Point Projections (IPP).\nA method for projecting genomic point coordinates between genomes with large evolutionary distances.')
+    parser.add_argument('regions_file', help='Bed file containing genomic coordinates. regions with width > 1 will be centered.')
+    parser.add_argument('ref', help='reference species')
+    parser.add_argument('qry', help='query species')
+    parser.add_argument('path_pwaln')
+    parser.add_argument('--out_dir', default=os.getcwd(), help='directory for output files')
+    parser.add_argument('--half_life_distance', type=int, default=10000, help='distance to closest anchor point at which projection score is 0.5')
+    parser.add_argument('--n_cores', type=int, default=1, help='number of CPUs')
+    parser.add_argument('--quiet', help='do not produce any verbose output')
+    parser.add_argument('--data_dir', default='/project/ipp-data')
+    args = parser.parse_args()
 
-  if not os.path.exists(args.out_dir):
-    os.mkdir(args.out_dir)
+    # define paths
+    assembly_dir = args.data_dir + '/assembly/'
 
-  # load pwaln pickle and copy to shared memory
-  print('Loading pairwise alignments from pickle')
-  load_pwaln(args.path_pwaln_pkl)
-  
-  # The list of species is determined based on the keys of the supplied pwaln dict.
-  genome_size = {s: read_genome_size(assembly_dir + s + '.sizes') for s in pwaln.keys()}
-  
-  # determine scaling factor based on desired distance_half_life (at which distance to an anchor in the reference species is the score supposed to be 0.5)
-  scaling_factor = get_scaling_factor(
-              genome_size[args.ref], 
-              int(args.half_life_distance))
+    if not os.path.exists(args.out_dir):
+        os.mkdir(args.out_dir)
 
-#   input('Press enter to start')
-  print('Projecting regions from %s to %s' %(args.ref, args.qry))
-  # create a process pool
-  pool = mp.Pool(processes=args.n_cores,
-                 initializer=init_worker,
-                 initargs=[pwaln_shared])
+    #input("about to init ipp")
+    myIpp = ipp.Ipp()
+    myIpp.load_pwalns(args.path_pwaln)
+    myIpp.load_genome_sizes(assembly_dir);
+    myIpp.set_half_life_distance(args.half_life_distance)
+
+    #input('Press enter to start')
+    print('Projecting regions from %s to %s' %(args.ref, args.qry))
+
+    # Read the regions file and enqueue one projection job per line.
+    ref_coords = []
+    with open(args.regions_file) as regions_file:
+        for line in regions_file.readlines():
+            cols = line.split('\t')
+            # define the coordinate as the center point between start and end coordinates
+            refChrom = cols[0]
+            refLoc = int(np.mean([int(cols[1]), int(cols[2])]))
+            ref_coords.append((refChrom, refLoc))
+
+    pbar = tqdm.tqdm(total=len(ref_coords), leave=False)
+    results = pd.DataFrame(
+        columns=['coords_ref', 'coords_direct', 'coords_multi',
+                 'score_direct', 'score_multi',
+                 'ref_anchor_direct_left', 'ref_anchor_direct_right', 'ref_anchor_multi_left', 'ref_anchor_multi_right',
+                 'qry_anchor_direct_left', 'qry_anchor_direct_right', 'qry_anchor_multi_left', 'qry_anchor_multi_right',
+                 'bridging_species'])
+    def on_job_done_callback(ref_coord,
+                             direct_score,
+                             direct_coords,
+                             direct_ref_anchors,
+                             direct_qry_anchors,
+                             multi_shortest_path):
+        assert multi_shortest_path[-1][0] == args.qry
+        multi_score = multi_shortest_path[-1][1]
+        multi_coords = multi_shortest_path[-1][2]
   
-  # callback function to append job result to collection of results
-  global results
-  results = pd.DataFrame()
-  def handle_job_complete(result):
-    global results, pbar
-    results = results.append(result)
-    pbar.update()
+        # Ref anchors of the first species in the path (first non-reference species)
+        multi_ref_anchors = multi_shortest_path[1][3]
+  
+        # Qry anchors of the last species in the path.
+        multi_qry_anchors = multi_shortest_path[-1][4]
+  
+        multi_bridging_species = \
+            ','.join([spe[0] for spe in multi_shortest_path[1:-1]])
+  
+        values = [ref_coord, direct_coords, multi_coords,
+                  direct_score, multi_score,
+                  direct_ref_anchors[0], direct_ref_anchors[1], multi_ref_anchors[0], multi_ref_anchors[1],
+                  direct_qry_anchors[0], direct_qry_anchors[1], multi_qry_anchors[0], multi_qry_anchors[1],
+                  multi_bridging_species]
+        nonlocal results
+        results = results.append(
+                pd.DataFrame([values], columns=results.columns),
+                ignore_index=True)
+  
+        pbar.update()
+  
+    # Start the projection
+    myIpp.project_coords(args.ref,
+                         args.qry,
+                         ref_coords,
+                         args.n_cores,
+                         on_job_done_callback)
+    pbar.close()
+  
+    print(results)
+  
+    ### TO DO:
+    ### name columns here and not in project_coord function
+    ### use ids from bed column 4 as index names (this should be part of the Coord class anyways, implement with that)
     
-  # error callback function in case project() fails
-  def handle_job_error(e):
-    global pbar
-    pbar.update()
-    try:
-      raise e
-    except KeyError:
-      # if not even dijkstra finds a projection (mostly due to chromosome border regions)
-      if not args.quiet:
-        print('Unable to map some region') #%s: %s' %(coord_id, coord))
-        print(e)
-        traceback.print_exc()
-        
-  # Read the regions file and enqueue one projection job per line.
-  nregions = sum(1 for _ in open(args.regions_file))
-  global pbar
-  pbar = tqdm.tqdm(total=nregions)
-  with open(args.regions_file) as regions_file:
-    for line in regions_file.readlines():
-      cols = line.split('\t')
-#       coord = Coord(chroms.index(cols[0]), int(cols[1]), cols[3])
-      # define the coordinate as the center point between start and end coordinates
-      coord = '{}:{}'.format(chroms.index(cols[0]), int(np.mean([int(cols[1]), int(cols[2])])))
-      job_args = (coord,
-                  args.ref,
-                  args.qry,
-                  genome_size,
-                  scaling_factor)
-      pool.apply_async(project_coord,
-                       job_args,
-                       callback=handle_job_complete,
-                       error_callback=handle_job_error)
-      
-  # Wait for the jobs to complete.
-  pool.close()
-  pool.join()
-  
-  ### TO DO:
-  ### name columns here and not in project_coord function
-  ### use ids from bed column 4 as index names (this should be part of the Coord class anyways, implement with that)
-  
-  # reformat '0:123456' to 'chr1:123456'
-#   results.columns = np.arange(len(results.columns))
-  coord_cols = ['coords_ref', 'coords_direct', 'coords_multi']
-  results.loc[:,coord_cols] = results.loc[:,coord_cols].apply(lambda x: ['{}:{}'.format(chroms[int(y.split(':')[0])], y.split(':')[1]) for y in x])
-  outfile = os.path.splitext(os.path.basename(args.regions_file))[0] + '.proj'
-  results.to_csv(os.path.join(args.out_dir, outfile), sep='\t', header=True)
+    outfile = os.path.splitext(os.path.basename(args.regions_file))[0] + '.proj'
+    results.to_csv(os.path.join(args.out_dir, outfile), sep='\t', header=True)
   
 if __name__ == '__main__':
-  main()
+    main()
 
-# vim: tabstop=2 shiftwidth=2 expandtab
+# vim: tabstop=4 shiftwidth=4 expandtab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from distutils.core import setup
+from distutils.extension import Extension
+import numpy as np
+
+ipp_extension = Extension('ipp',
+                          ['ippmodule.cpp', 'ipp.cpp'],
+                          include_dirs=[np.get_include()],
+                          extra_compile_args=['-O0'])
+setup(name='ipp',
+      version='1.0',
+      description='This is the IPP package',
+      ext_modules=[ipp_extension])


### PR DESCRIPTION
Moved the whole ipp logic into a c++ Python module in order to run coordinate projections in parallel threads.

This implementation is quite a bit faster than the one in Python and uses less memory, too.

You can use it by first compiling the module:
```
$ python setup.py build
```

Then, you need to tell Python where to look for your module (use the directory that is created according to your Python version):
```
$ export PYTHONPATH=build/lib.linux-x86_64-3.10/
```
Now you need to re-format the pwaln file:
```
$ ./pickle_to_bin.py data/mm39.galGal6.pwaln.shrunk.pkl
```

The above generates a new file `data/mm39.galGal6.pwaln.shrunk.bin` which you should now use as the pwaln file in `project.py`.